### PR TITLE
change the subtitle box from metabox to a regular old field

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -9,7 +9,8 @@
 load_plugin_textdomain( 'wp-subtitle', false, dirname( WPSUBTITLE_BASENAME ) . '/languages' );
 
 // Includes
-add_action( 'add_meta_boxes', array( 'WPSubtitle_Admin', '_add_meta_boxes' ) );
+add_action( 'edit_form_after_title', array( 'WPSubtitle_Admin', '_add_subtitle_field' ) );
+//add_action( 'add_meta_boxes', array( 'WPSubtitle_Admin', '_add_meta_boxes' ) );
 add_action( 'save_post', array( 'WPSubtitle_Admin', '_save_post' ) );
 
 class WPSubtitle_Admin {
@@ -45,6 +46,26 @@ class WPSubtitle_Admin {
 		global $post;
 		echo '<input type="hidden" name="wps_noncename" id="wps_noncename" value="' . wp_create_nonce( 'wp-subtitle' ) . '" />';
 		echo '<input type="text" id="wpsubtitle" name="wps_subtitle" value="' . WPSubtitle::_get_post_meta( $post->ID ) . '" style="width:99%;" />';
+		echo apply_filters( 'wps_subtitle_field_description', '', $post );
+	}
+
+	/**
+	 * Add Subtitle Field
+	 *
+	 * @since  2.0
+	 * @internal
+	 *
+	 * @uses  WPSubtitle::_get_post_meta()
+	 * @uses  apply_filters( 'wps_subtitle_field_description' )
+	 */
+	static function _add_subtitle_field() {
+		global $post;
+		echo '<div id="subtitlediv" style="position: relative;margin-bottom: 10px">';
+			echo '<div id="subtitlewrap" style="border: 0;padding: 0;">';
+				echo '<input type="text" id="wpsubtitle" name="wps_subtitle" value="' . WPSubtitle::_get_post_meta( $post->ID ) . '" placeholder="'.apply_filters( 'wps_enter_subtitle_here', __( 'Enter subtitle here...', 'wp-subtitle' ) ).'" autocomplete="off" style="padding: 3px 8px;font-size: 1.4em;line-height: 100%;width:100%;height: 1.7em;outline: 0;margin: 0;background-color: #fff;" />';
+			echo '</div>';
+		echo '</div>';
+		echo '<input type="hidden" name="wps_noncename" id="wps_noncename" value="' . wp_create_nonce( 'wp-subtitle' ) . '" />';
 		echo apply_filters( 'wps_subtitle_field_description', '', $post );
 	}
 


### PR DESCRIPTION
The subtitle field in the metabox looks misplaced (when in a metabox). Something like this would maybe be better, where the subtitle field is placed just below the title field.
