### PR TITLE
Fix PHP Notice Warning On 404 Error Page

### DIFF
--- a/wp-subtitle.php
+++ b/wp-subtitle.php
@@ -114,7 +114,7 @@ class WPSubtitle {
 	 */
 	static function get_the_subtitle( $post = 0 ) {
 		$post = get_post( $post );
-		if ( WPSubtitle::is_supported_post_type( $post->post_type ) ) {
+		if ( !empty($post) && WPSubtitle::is_supported_post_type( $post->post_type ) ) {
 			$subtitle = WPSubtitle::_get_post_meta( $post );
 			return apply_filters( 'wps_subtitle', $subtitle, $post );
 		}

--- a/wp-subtitle.php
+++ b/wp-subtitle.php
@@ -114,7 +114,7 @@ class WPSubtitle {
 	 */
 	static function get_the_subtitle( $post = 0 ) {
 		$post = get_post( $post );
-		if ( !empty($post) && WPSubtitle::is_supported_post_type( $post->post_type ) ) {
+		if ( !empty( $post ) && WPSubtitle::is_supported_post_type( $post->post_type ) ) {
 			$subtitle = WPSubtitle::_get_post_meta( $post );
 			return apply_filters( 'wps_subtitle', $subtitle, $post );
 		}

--- a/wp-subtitle.php
+++ b/wp-subtitle.php
@@ -114,7 +114,7 @@ class WPSubtitle {
 	 */
 	static function get_the_subtitle( $post = 0 ) {
 		$post = get_post( $post );
-		if ( !empty( $post ) && WPSubtitle::is_supported_post_type( $post->post_type ) ) {
+		if ( $post && WPSubtitle::is_supported_post_type( $post->post_type ) ) {
 			$subtitle = WPSubtitle::_get_post_meta( $post );
 			return apply_filters( 'wps_subtitle', $subtitle, $post );
 		}


### PR DESCRIPTION
When viewing the 404 error page in WordPress, this plugin creates a php notice warning, as it's not actually on a post. This is easily fixed by first checking if there is any data before doing the lookup.

> Notice: Trying to get property of non-object in plugins/wp-subtitle/wp-subtitle.php on line 117