### PR TITLE
apply wptexturize() on subtitles

### DIFF
--- a/wp-subtitle.php
+++ b/wp-subtitle.php
@@ -169,7 +169,7 @@ function get_the_subtitle( $post = 0, $before = '', $after = '', $echo = true ) 
 	$subtitle = WPSubtitle::get_the_subtitle( $post );
 
 	if ( ! empty( $subtitle ) ) {
-		$subtitle = $before . $subtitle . $after;
+		$subtitle = wptexturize( $before . $subtitle . $after );
 	}
 
 	if ( ! $echo ) {


### PR DESCRIPTION
Gives subtitles the same typographic enhancements as `the_title()`.
As suggested in https://github.com/benhuson/wp-subtitle/issues/16.