### PR TITLE
Add subtitle support for terms.

### DIFF
--- a/plugin/admin/admin-terms.php
+++ b/plugin/admin/admin-terms.php
@@ -1,0 +1,171 @@
+<?php
+
+/**
+ * @package     WP Subtitle
+ * @subpackage  Admin Terms
+ */
+
+add_action( 'plugins_loaded', array( 'WPSubtitle_Admin_Terms', 'setup_hooks' ) );
+
+class WPSubtitle_Admin_Terms {
+
+	/**
+	 * Setup Hooks
+	 */
+	public static function setup_hooks() {
+
+		add_action( 'admin_init', array( get_class(), 'add_admin_fields' ) );
+
+		$taxonomies = self::get_supported_taxonomies();
+
+		foreach ( $taxonomies as $taxonomy ) {
+			add_filter( 'manage_edit-' . $taxonomy . '_columns', array( get_class(), 'taxonomy_columns' ) );
+			add_filter( 'manage_' . $taxonomy . '_custom_column', array( get_class(), 'term_row' ), 15, 3 );
+			add_action( 'create_' . $taxonomy, array( get_class(), 'update_term_meta' ), 10 );
+			add_action( 'edited_' . $taxonomy, array( get_class(), 'update_term_meta' ), 10 );
+		}
+
+	}
+
+	/**
+	 * Edit Taxonomy Columns
+	 *
+	 * @param   array  A list of columns.
+	 * @return  array  List of columns with "Subtitle" inserted after the title.
+	 *
+	 * @internal  Private. Called via the `manage_edit-{$taxonomy}_columns` filter.
+	 */
+	public function taxonomy_columns( $original_columns ) {
+
+		$new_columns = array();
+
+		foreach ( $original_columns as $key => $value ) {
+
+			$new_columns[ $key ] = $value;
+
+			if ( 'name' == $key ) {
+				$new_columns['subtitle'] = esc_html__( 'Subtitle', 'wp-subtitle' );
+			}
+
+		}
+
+		return $new_columns;
+
+	}
+
+	/**
+	 * Edit Term Row
+	 *
+	 * @param   string   Row.
+	 * @param   string   Name of the current column.
+	 * @param   integer  Term ID.
+	 * @return  string   HTML display.
+	 *
+	 * @internal  Private.  Called via the `manage_{$taxonomy}_custom_column` filter.
+	 */
+	public function term_row( $row, $column_name, $term_id ) {
+
+		if ( 'subtitle' === $column_name ) {
+
+			$subtitle = new WP_Subtitle_Term( $term_id );
+
+			return $row . esc_html( $subtitle->get_meta_value() );
+
+		}
+
+		return $row;
+
+	}
+
+	/**
+	 * Add Admin Fields
+	 *
+	 * @internal  Private. Called via the `admin_init` action.
+	 */
+	public static function add_admin_fields() {
+
+		$taxonomies = self::get_supported_taxonomies();
+
+		foreach ( $taxonomies as $taxonomy ) {
+			add_action( $taxonomy . '_add_form_fields', array( get_class(), 'add_form' ) );
+			add_action( $taxonomy . '_edit_form_fields', array( get_class(), 'edit_form' ), 30, 2 );
+		}
+
+	}
+
+	/**
+	 * Add Term Form
+	 *
+	 * Create image control for `wp-admin/term.php`.
+	 *
+	 * @param  string   Taxonomy slug.
+	 *
+	 * @internal  Private. Called via the `{$taxonomy}_add_form_fields` action.
+	 */
+	public static function add_form( $taxonomy ) {
+
+		?>
+		<div class="form-field term-wps-subtitle-wrap">
+			<label for="wps_subtitle"><?php esc_html_e( 'Subtitle', 'wp-subtitle' ); ?></label>
+			<input name="wps_subtitle" id="wps_subtitle" type="text" value="" size="40">
+		</div>
+		<?php
+
+	}
+
+	/**
+	 * Edit Term Form
+	 *
+	 * Create image control for `wp-admin/term.php`.
+	 *
+	 * @param  WP_Term  Term object.
+	 * @param  string   Taxonomy slug.
+	 *
+	 * @internal  Private. Called via the `{$taxonomy}_edit_form_fields` action.
+	 */
+	public static function edit_form( $term, $taxonomy ) {
+
+		$term_subtitle = new WP_Subtitle_Term( $term );
+
+		?>
+		<tr class="form-field term-wps-subtitle-wrap">
+			<th scope="row"><label for="wps_subtitle"><?php esc_html_e( 'Subtitle', 'wp-subtitle' ); ?></label></th>
+			<td><input name="wps_subtitle" id="wps_subtitle" type="text" value="<?php echo esc_attr( $term_subtitle->get_meta_value() ); ?>" size="40"></td>
+		</tr>
+		<?php
+
+	}
+
+	/**
+	 * Update Term Meta
+	 *
+	 * @param  integer  $term_id  Term ID.
+	 *
+	 * @internal  Private. Called via the `edited_{$taxonomy}` action.
+	 */
+	public static function update_term_meta( $term_id ) {
+
+		$term_subtitle = new WP_Subtitle_Term( $term_id );
+
+		if ( ! $term_subtitle->current_user_can_edit() ) {
+			return;
+		}
+
+		if ( isset( $_POST[ 'wps_subtitle' ] ) ) {
+			$term_subtitle->update_subtitle( $_POST[ 'wps_subtitle' ] );
+		}
+
+	}
+
+	/**
+	 * Get Supported Taxonomies
+	 *
+	 * @return  array
+	 */
+	private static function get_supported_taxonomies() {
+
+		return apply_filters( 'plugins/wp_subtitle/supported_taxonomies', array( 'category' ) );
+
+	}
+
+}

--- a/plugin/includes/class-api.php
+++ b/plugin/includes/class-api.php
@@ -20,6 +20,34 @@
  *    'after'  => '</p>',                  // After subtitle HTML output (default empty string)
  *    'post_id' => get_the_ID()            // Post ID (default current post ID)
  * ) );
+ *
+ * // Example: Display term subtitle
+ * do_action( 'plugins/wp_subtitle/the_term_subtitle', array(
+ *    'before'        => '<p class="subtitle">',  // Before subtitle HTML output (default empty string)
+ *    'after'         => '</p>',                  // After subtitle HTML output (default empty string)
+ *    'term_id'       => 0,                       // Term ID (default to none)
+ *    'default_value' => ''                       // Default output (if no subtitle)
+ * ) );
+ *
+ * // Example: Get term subtitle display
+ * $subtitle = apply_filters( 'plugins/wp_subtitle/get_term_subtitle', '', array(
+ *    'before' => '<p class="subtitle">',  // Before subtitle HTML output (default empty string)
+ *    'after'  => '</p>',                  // After subtitle HTML output (default empty string)
+ *    'term_id' => 0                       // Term ID (default to none)
+ * ) );
+ *
+ * // Example: Display archive subtitle
+ * do_action( 'plugins/wp_subtitle/the_archive_subtitle', array(
+ *    'before'        => '<p class="subtitle">',  // Before subtitle HTML output (default empty string)
+ *    'after'         => '</p>',                  // After subtitle HTML output (default empty string)
+ *    'default_value' => ''                       // Default output (if no subtitle)
+ * ) );
+ *
+ * // Example: Get archive subtitle display
+ * $subtitle = apply_filters( 'plugins/wp_subtitle/get_archive_subtitle', '', array(
+ *    'before' => '<p class="subtitle">',  // Before subtitle HTML output (default empty string)
+ *    'after'  => '</p>',                  // After subtitle HTML output (default empty string)
+ * ) );
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
@@ -122,6 +150,9 @@ class WP_Subtitle_API {
 
 	/**
 	 * The Archive Subtitle (Filter)
+	 *
+	 * If the main blog page when posts page is set, get the subtitle of the page.
+	 * If a categiry/tag/term archive, get the term subtitle.
 	 *
 	 * @param   string  $subtitle  Subtitle.
 	 * @param   array   $args      Display args.

--- a/plugin/includes/class-api.php
+++ b/plugin/includes/class-api.php
@@ -34,6 +34,9 @@ class WP_Subtitle_API {
 		add_action( 'plugins/wp_subtitle/the_subtitle', array( $this, 'the_subtitle' ) );
 		add_filter( 'plugins/wp_subtitle/get_subtitle', array( $this, 'get_subtitle' ), 10, 2 );
 
+		add_action( 'plugins/wp_subtitle/the_term_subtitle', array( $this, 'the_term_subtitle' ) );
+		add_filter( 'plugins/wp_subtitle/get_term_subtitle', array( $this, 'get_term_subtitle' ), 10, 2 );
+
 	}
 
 	/**
@@ -62,11 +65,7 @@ class WP_Subtitle_API {
 	 */
 	public function get_subtitle( $default_subtitle, $args = '' ) {
 
-		$args = wp_parse_args( $args, array(
-			'post_id' => get_the_ID(),  // Post ID
-			'before'  => '',            // Before subtitle HTML output
-			'after'   => ''             // After subtitle HTML output
-		) );
+		$args = $this->post_parse_args( $args );
 
 		$subtitle_obj = new WP_Subtitle( $args['post_id'] );
 		$subtitle = $subtitle_obj->get_subtitle( $args );
@@ -76,6 +75,87 @@ class WP_Subtitle_API {
 		}
 
 		return $default_subtitle;
+
+	}
+
+	/**
+	 * The Term Subtitle (Action)
+	 *
+	 * @param  array  $args  Display args.
+	 */
+	public function the_term_subtitle( $args = '' ) {
+
+		echo apply_filters( 'plugins/wp_subtitle/get_term_subtitle', '', $args );
+
+	}
+
+	/**
+	 * The Subtitle (Filter)
+	 *
+	 * @param   string  $subtitle  Subtitle.
+	 * @param   array   $args      Display args.
+	 * @return  string             Subtitle.
+	 */
+	public function get_term_subtitle( $subtitle = '', $args = '' ) {
+
+		$args = $this->term_parse_args( $args );
+
+		$subtitle = new WP_Subtitle_Term( $args['term_id'] );
+
+		return $this->get_display( $subtitle->get_meta_value(), $args );
+
+	}
+
+	/**
+	 * Get Display
+	 *
+	 * @param   string  $subtitle  Subtitle.
+	 * @param   array   $args      Display args.
+	 * @return  string             Subtitle.
+	 */
+	protected function get_display( $subtitle, $args ) {
+
+		if ( ! empty( $subtitle ) ) {
+			$subtitle = $args['before'] . $subtitle . $args['after'];
+		}
+
+		return $subtitle;
+
+	}
+
+	/**
+	 * Post Parse Args
+	 *
+	 * @param   array  $args  Args.
+	 * @return  array         Args.
+	 */
+	protected function post_parse_args( $args = '' ) {
+
+		$args = wp_parse_args( $args, array(
+			'post_id' => get_the_ID(),  // Post ID
+			'before'  => '',            // Before subtitle HTML output
+			'after'   => ''             // After subtitle HTML output
+		) );
+
+		return $args;
+
+	}
+
+	/**
+	 * Term Parse Args
+	 *
+	 * @param   array  $args  Args.
+	 * @return  array         Args.
+	 */
+	protected function term_parse_args( $args = '' ) {
+
+		$args = wp_parse_args( $args, array(
+			'term_id' => is_category() || is_tag() || is_tax() ? get_queried_object_id() : 0,
+			'before'  => '',
+			'after'   => ''
+		) );
+
+		return $args;
 
 	}
 

--- a/plugin/includes/subtitle-term.php
+++ b/plugin/includes/subtitle-term.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * @package     WP Subtitle
+ * @subpackage  Term Class
+ */
+
+class WP_Subtitle_Term {
+
+	/**
+	 * Object ID
+	 *
+	 * @var  integer
+	 */
+	protected $term_id = 0;
+
+	/**
+	 * Constructor
+	 *
+	 * @param  integer|WP_Term  $term  Term object or ID.
+	 */
+	public function __construct( $term ) {
+
+		if ( is_a( $term, 'WP_Term' ) ) {
+			$this->object_id = absint( $term->term_id );
+		} else {
+			$this->object_id = absint( $term );
+		}
+
+	}
+
+	/**
+	 * Get Meta Value
+	 *
+	 * @return  string  The subtitle meta value.
+	 */
+	public function get_meta_value() {
+
+		return get_term_meta( $this->object_id, $this->get_meta_key(), true );
+
+	}
+
+	/**
+	 * Update Subtitle
+	 *
+	 * @param   string                 $subtitle  Subtitle.
+	 * @return  integer|WP_Error|bool             Meta ID if new entry. True if updated, false if not updated or the same
+	 *                                            as current value.  WP_Error when term_id is ambiguous between taxonomies.
+	 */
+	public function update_subtitle( $subtitle ) {
+
+		$subtitle = trim( sanitize_text_field( $subtitle ) );
+
+		if ( '' == $subtitle ) {
+			return $this->delete_subtitle();
+		}
+
+		return update_term_meta( $this->object_id, $this->get_meta_key(), $subtitle );
+
+	}
+
+	/**
+	 * Delete Subtitle
+	 *
+	 * @return  boolean  True if deleted, false if failed.
+	 */
+	protected function delete_subtitle() {
+
+		return delete_term_meta( $this->object_id, $this->get_meta_key() );
+
+	}
+
+	/**
+	 * Get Meta Key
+	 *
+	 * @return  string  The subtitle meta key.
+	 */
+	protected function get_meta_key() {
+
+		return 'wps_subtitle';
+
+	}
+
+	/**
+	 * Current User Can Edit
+	 *
+	 * @return  boolean
+	 */
+	public function current_user_can_edit() {
+
+		$term = get_term( $this->object_id );
+		$tax = get_taxonomy( $term->taxonomy );
+
+		return current_user_can( $tax->cap->edit_terms );
+
+	}
+
+}

--- a/plugin/plugin.php
+++ b/plugin/plugin.php
@@ -14,6 +14,7 @@ define( 'WPSUBTITLE_DIR', plugin_dir_path( __FILE__ ) );
 // Includes
 include_once( WPSUBTITLE_DIR . 'includes/class-api.php' );
 include_once( WPSUBTITLE_DIR . 'includes/subtitle.php' );
+require_once( WPSUBTITLE_DIR . 'includes/subtitle-term.php' );
 include_once( WPSUBTITLE_DIR . 'includes/deprecated.php' );
 include_once( WPSUBTITLE_DIR . 'includes/shortcode.php' );
 include_once( WPSUBTITLE_DIR . 'includes/rest.php' );
@@ -24,6 +25,8 @@ include_once( WPSUBTITLE_DIR . 'includes/compat/woocommerce.php' );
 // Include admin-only functionality
 if ( is_admin() ) {
 	require_once( WPSUBTITLE_DIR . 'admin/admin.php' );
+	require_once( WPSUBTITLE_DIR . 'admin/admin-terms.php' );
+
 	if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 		// Load AJAX functions here if required...
 	} else {


### PR DESCRIPTION
Includes API for display term subtitles (based on term ID) and archive subtitles (displayed for taxonomy term pages):

```
// Example: Display term subtitle
do_action( 'plugins/wp_subtitle/the_term_subtitle', array(
   'before'        => '<p class="subtitle">',  // Before subtitle HTML output (default empty string)
   'after'         => '</p>',                  // After subtitle HTML output (default empty string)
   'term_id'       => 0,                       // Term ID (default to none)
   'default_value' => ''                       // Default output (if no subtitle)
) );

// Example: Get term subtitle display
$subtitle = apply_filters( 'plugins/wp_subtitle/get_term_subtitle', '', array(
   'before' => '<p class="subtitle">',  // Before subtitle HTML output (default empty string)
   'after'  => '</p>',                  // After subtitle HTML output (default empty string)
   'term_id' => 0                       // Term ID (default to none)
) );

// Example: Display archive subtitle
do_action( 'plugins/wp_subtitle/the_archive_subtitle', array(
   'before'        => '<p class="subtitle">',  // Before subtitle HTML output (default empty string)
   'after'         => '</p>',                  // After subtitle HTML output (default empty string)
   'default_value' => ''                       // Default output (if no subtitle)
) );

// Example: Get archive subtitle display
$subtitle = apply_filters( 'plugins/wp_subtitle/get_archive_subtitle', '', array(
   'before' => '<p class="subtitle">',  // Before subtitle HTML output (default empty string)
   'after'  => '</p>',                  // After subtitle HTML output (default empty string)
) );
```